### PR TITLE
Eliminar is_siteadmin() para respetar capabilities locales y cambio de rol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Todas las modificaciones importantes del proyecto se documentarán en este archivo.
 
+## [2.0.4] - 2026-01-18
+- Se eliminaron las comprobaciones redundantes de administrador (`is_siteadmin()`) en varias vistas clave, mejorando la detección correcta de roles locales (profesores vs estudiantes) y el sistema de permisos basado en capacidades.
+
 ## [2.0.3] — 2026-01-18
 - Opción para mostrar/ocultar las descripciones en el bloque principal.
 - Adición del gráfico radar en resultados detallados y acceso permitido a los estudiantes a esta vista.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Todas las modificaciones importantes del proyecto se documentarán en este archi
 
 ## [2.0.4] - 2026-01-18
 - Se eliminaron las comprobaciones redundantes de administrador (`is_siteadmin()`) en varias vistas clave, mejorando la detección correcta de roles locales (profesores vs estudiantes) y el sistema de permisos basado en capacidades.
+- Se agrega negrilla en el titulo del bloque para mejorar la visibilidad.
 
 ## [2.0.3] — 2026-01-18
 - Opción para mostrar/ocultar las descripciones en el bloque principal.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Este repositorio incluye:
 
 El recorrido comienza con una invitación clara y directa. Desde el bloque principal del curso, el estudiante puede visualizar su estado actual y acceder al test con un solo click, facilitando la participación sin fricciones.
 <p align="center">
-  <img src="https://github.com/user-attachments/assets/c7ba3e79-0ce2-422c-b472-5d7140c87ae9" alt="Invitación al Test" width="528">
+  <img src="https://github.com/user-attachments/assets/69118227-0b1b-4c4b-9551-a42fef48b5e6" alt="Invitación al Test" width="528">
 </p>
 
 **Interfaz de Evaluación Optimizada**
@@ -74,7 +74,7 @@ Para garantizar la integridad de los datos, el sistema implementa una validació
 Entendemos que el tiempo es valioso. Si el estudiante debe interrumpir su sesión, el sistema guarda automáticamente su avance. Al regresar, el bloque muestra el porcentaje de progreso y permite reanudar el test exactamente donde se dejó, resaltando visualmente la siguiente pregunta a responder.
 	
 <p align="center">
-  <img src="https://github.com/user-attachments/assets/e3b7f7e2-3085-4d42-8d84-48011ef8557c" alt="Progreso del Test" height="350">
+  <img src="https://github.com/user-attachments/assets/26c6b6b9-cddd-42fd-b18a-4b6d950a4ec9" alt="Progreso del Test" height="350">
   &nbsp;&nbsp;
   <img src="https://github.com/user-attachments/assets/002b5f98-beee-453e-a044-1454d05130c8" alt="Continuar Test" height="350">
 </p>
@@ -83,7 +83,7 @@ Entendemos que el tiempo es valioso. Si el estudiante debe interrumpir su sesió
 Si el estudiante ha completado las 44 preguntas pero aún no ha procesado el envío, el bloque muestra una notificación clara y amigable, invitándolo a formalizar la entrega y conocer su tipo de personalidad.
 
 <p align="center">
-  <img src="https://github.com/user-attachments/assets/15915dfa-79ec-40f8-9d7d-9907e81ea15b" alt="Confirmación de Test Completado" width="528">
+  <img src="https://github.com/user-attachments/assets/b0966bc7-1e0f-48a3-b301-f02b777eb781" alt="Confirmación de Test Completado" width="528">
 </p>
 
 **Análisis de Perfil y Recomendaciones Personalizadas**

--- a/admin_view.php
+++ b/admin_view.php
@@ -33,7 +33,7 @@ if (!$DB->record_exists('block_instances', array('blockname' => 'personality_tes
 }
 
 // Friendly redirect for unauthorized users
-if (!has_capability('block/personality_test:viewreports', $context) && !is_siteadmin()) {
+if (!has_capability('block/personality_test:viewreports', $context)) {
     redirect(new moodle_url('/course/view.php', array('id' => $courseid)));
 }
 
@@ -53,11 +53,8 @@ if ($action === 'delete' && $userid && confirm_sesskey()) {
     if ($confirm) {
         // Privacy check
         $targetuser = $DB->get_record('user', array('id' => $userid), '*', MUST_EXIST);
-        if (!is_siteadmin() && (
-            !is_enrolled($context, $targetuser, 'block/personality_test:taketest', true)
-            || has_capability('block/personality_test:viewreports', $context, $userid)
-            || is_siteadmin($userid)
-        )) {
+        if (!is_enrolled($context, $targetuser, 'block/personality_test:taketest', true)
+            || has_capability('block/personality_test:viewreports', $context, $userid)) {
              redirect(new moodle_url('/course/view.php', array('id' => $courseid)));
         }
         

--- a/block_personality_test.php
+++ b/block_personality_test.php
@@ -99,9 +99,6 @@ class block_personality_test extends block_base
         $filtered_student_ids = array();
         foreach ($student_ids as $candidateid) {
             $candidateid = (int)$candidateid;
-            if (is_siteadmin($candidateid)) {
-                continue;
-            }
             if (has_capability('block/personality_test:viewreports', $context, $candidateid)) {
                 continue;
             }

--- a/download_pdf.php
+++ b/download_pdf.php
@@ -44,7 +44,7 @@ if ($userid) {
     $context = context_course::instance($course->id);
     require_login($course, false);
 
-    $canviewreports = has_capability('block/personality_test:viewreports', $context) || is_siteadmin();
+    $canviewreports = has_capability('block/personality_test:viewreports', $context);
     if (!$canviewreports && (int)$userid !== (int)$USER->id) {
         redirect(new moodle_url('/course/view.php', ['id' => $course->id]));
     }

--- a/lang/en/block_personality_test.php
+++ b/lang/en/block_personality_test.php
@@ -265,7 +265,7 @@ $string['mbti_dimensions_enfj'] = 'Extraversion - Intuition - Feeling - Judging'
 $string['mbti_dimensions_entj'] = 'Extraversion - Intuition - Thinking - Judging';
 
 // Test invitation
-$string['test_title'] = 'Personality ';
+$string['test_title'] = 'Personality Exploration';
 $string['discover_your_personality'] = 'Discover your personality type';
 $string['what_is_mbti'] = 'What is the Myers-Briggs Type Indicator (MBTI)?';
 $string['test_description'] = 'A self-reflective tool designed to reveal your natural preferences across four fundamental dimensions. Its goal is to provide you with a detailed profile of your strengths, blind spots, and how you interact with the world and the people around you.';

--- a/lib.php
+++ b/lib.php
@@ -77,7 +77,7 @@ function block_personality_test_get_report_data($courseid) {
     require_login($course, false);
     
     // Check permissions
-    if (!has_capability('block/personality_test:viewreports', $context) && !is_siteadmin()) {
+    if (!has_capability('block/personality_test:viewreports', $context)) {
         return false;
     }
     
@@ -89,9 +89,6 @@ function block_personality_test_get_report_data($courseid) {
     $student_ids = array();
     foreach ($enrolled_ids as $candidateid) {
         $candidateid = (int)$candidateid;
-        if (is_siteadmin($candidateid)) {
-            continue;
-        }
         if (has_capability('block/personality_test:viewreports', $context, $candidateid)) {
             continue;
         }

--- a/templates/student_continue.mustache
+++ b/templates/student_continue.mustache
@@ -1,7 +1,7 @@
 <div class="personality-invitation-block" style="padding: 15px; background: linear-gradient(135deg, #e3f2fd 0%, #f8f9fa 100%); border-radius: 8px; border: 1px solid #dee2e6;">
     <div class="personality-header text-center mb-3">
         {{{icon}}}
-        <h6 class="mt-2 mb-1">{{#str}}test_title, block_personality_test{{/str}}</h6>
+        <h6 class="mt-2 mb-1 font-weight-bold">{{#str}}test_title, block_personality_test{{/str}}</h6>
         <small class="text-muted">{{#str}}discover_your_personality, block_personality_test{{/str}}</small>
     </div>
     

--- a/templates/student_invitation.mustache
+++ b/templates/student_invitation.mustache
@@ -1,7 +1,7 @@
 <div class="personality-invitation-block">
     <div class="personality-header text-center mb-3">
         {{{icon}}}
-        <h6 class="mt-2 mb-1">{{#str}}test_title, block_personality_test{{/str}}</h6>
+        <h6 class="mt-2 mb-1 font-weight-bold">{{#str}}test_title, block_personality_test{{/str}}</h6>
         <small class="text-muted">{{#str}}discover_your_personality, block_personality_test{{/str}}</small>
     </div>
     

--- a/templates/student_results.mustache
+++ b/templates/student_results.mustache
@@ -32,7 +32,7 @@
     
     <div class="text-center">
         <a href="{{summary_url}}" class="btn btn-sm" style="background: linear-gradient(135deg, #00dda9ff 0%, #00a07a 100%); border: none; color: #fff; width: 100%; font-weight: 500;">
-            <i class="fa fa-chart-bar"></i> {{#str}} see_detailed_results, block_personality_test {{/str}}
+            <i class="fa fa-eye"></i> {{#str}} see_detailed_results, block_personality_test {{/str}}
         </a>
     </div>
 </div>

--- a/templates/student_results.mustache
+++ b/templates/student_results.mustache
@@ -4,7 +4,7 @@
             {{{icon}}}
             <i class="fa fa-check" style="position: absolute; top: -6px; right: -9px; font-size: 1.4em; background: white; border-radius: 50%; line-height: 1; text-shadow: 0 1px 2px rgba(0,0,0,0.1); color: #00bf91;"></i>
         </div>
-        <h6 class="mt-2 mb-1">{{#str}}test_completed, block_personality_test{{/str}}</h6>
+        <h6 class="mt-2 mb-1 font-weight-bold">{{#str}}test_completed, block_personality_test{{/str}}</h6>
         <small class="text-muted">{{#str}}your_results_here, block_personality_test{{/str}}</small>
     </div>
     

--- a/version.php
+++ b/version.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Personality Test Block Major Update
- * Version 2.0.3 - Production Ready
+ * Version 2.0.4 - Production Ready
  *
  * @package    block_personality_test
  * @copyright  2026 Jairo Serrano, Yuranis Henriquez, Isaac Sanchez, Santiago Orejuela, Maria Valentina
@@ -10,8 +10,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2026011800; // YYYYMMDDXX (year, month, day, 2-digit version number).
+$plugin->version = 2026011801; // YYYYMMDDXX (year, month, day, 2-digit version number).
 $plugin->requires = 2022041900; // Moodle 4.0+
 $plugin->component = 'block_personality_test';
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '2.0.3';
+$plugin->release = '2.0.4';

--- a/view_individual.php
+++ b/view_individual.php
@@ -22,16 +22,15 @@ $test_result = $DB->get_record('personality_test', array('user' => $userid));
 // Verificar permisos y manejo de privacidad
 $is_own_results = ($USER->id == $userid);
 $can_view_reports = has_capability('block/personality_test:viewreports', $context);
-$is_siteadmin = is_siteadmin($USER);
 
 // Acceso básico: Si no es propietario, ni profesor (con permisos), ni admin -> Redirigir
-if (!$is_own_results && !$can_view_reports && !$is_siteadmin) {
+if (!$is_own_results && !$can_view_reports) {
     redirect(new moodle_url('/course/view.php', array('id' => $courseid)));
 }
 
 // Check if teacher can access this specific user info (Grouping check)
 // Si no es admin y no son sus propios resultados...
-if (!$is_siteadmin && !$is_own_results) {
+if (!$is_own_results) {
     // Si el usuario tiene la capacidad de ver todos los grupos, permitir.
     if (!has_capability('moodle/site:accessallgroups', $context)) {
         // Obtener grupos del profesor y del estudiante objetivo


### PR DESCRIPTION
Este PR corrige la lógica de permisos del bloque para que respete el contexto del curso en lugar de los permisos globales del sitio.

### Cambios realizados:
- Se eliminaron las llamadas a `is_siteadmin()` y `!is_siteadmin()` en la lógica de acceso y generación de reportes.
- Ahora el acceso se determina exclusivamente mediante `has_capability('block/pluginname:viewreports', $context)`.
- Negrilla en titulo principal del bloque para consistencia con los demás

### Beneficios:
- **QA Mejorado:** Permite a los administradores usar la función "Cambiar rol a -> Estudiante" y ver el bloque exactamente como lo vería un alumno.
- **Consistencia:** Si un admin se matricula como estudiante en un curso, ahora aparecerá correctamente en los reportes y listas de clase en lugar de ser filtrado automáticamente.