### PR TITLE
Renovación SAVIO: permisos y panel protegido de Personalidad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Todas las modificaciones importantes del proyecto se documentarán en este archivo.
 
+## [2.0.5] — 2026-07-28
+
+### Cambiado
+- El bloque muestra un lanzador compacto del panel administrativo a los usuarios autorizados, sin estadísticas ni resultados en la página del curso.
+- Se unificaron las plantillas de administración y de resultados individuales, incluidos los textos de acceso en español e inglés.
+
+### Seguridad
+- Se incorporaron las capacidades `viewstudentdata` y `deletestudentdata` para separar la consulta/exportación de la eliminación de respuestas.
+- Los datos de estudiantes dejaron de estar disponibles automáticamente para roles docentes.
+- Se eliminó la capacidad heredada e inactiva `viewreports`.
+
 ## [2.0.4] - 2026-01-18
 - Se eliminaron las comprobaciones redundantes de administrador (`is_siteadmin()`) en varias vistas clave, mejorando la detección correcta de roles locales (profesores vs estudiantes) y el sistema de permisos basado en capacidades.
 - Se agrega negrilla en el titulo del bloque para mejorar la visibilidad.

--- a/admin_view.php
+++ b/admin_view.php
@@ -33,7 +33,7 @@ if (!$DB->record_exists('block_instances', array('blockname' => 'personality_tes
 }
 
 // Friendly redirect for unauthorized users
-if (!has_capability('block/personality_test:viewreports', $context)) {
+if (!has_capability('block/personality_test:viewstudentdata', $context)) {
     redirect(new moodle_url('/course/view.php', array('id' => $courseid)));
 }
 
@@ -48,13 +48,17 @@ $admin_url = new moodle_url('/blocks/personality_test/admin_view.php', array('ci
 $PAGE->set_url($admin_url);
 
 // Handle Delete Action
+if ($action === 'delete' && $userid && !has_capability('block/personality_test:deletestudentdata', $context)) {
+    redirect($admin_url);
+}
+
 if ($action === 'delete' && $userid && confirm_sesskey()) {
     $confirm = optional_param('confirm', 0, PARAM_INT);
     if ($confirm) {
         // Privacy check
         $targetuser = $DB->get_record('user', array('id' => $userid), '*', MUST_EXIST);
         if (!is_enrolled($context, $targetuser, 'block/personality_test:taketest', true)
-            || has_capability('block/personality_test:viewreports', $context, $userid)) {
+            || has_capability('block/personality_test:viewstudentdata', $context, $userid)) {
              redirect(new moodle_url('/course/view.php', array('id' => $courseid)));
         }
         
@@ -64,7 +68,7 @@ if ($action === 'delete' && $userid && confirm_sesskey()) {
 }
 
 $title = get_string('admin_manage_title', 'block_personality_test');
-$PAGE->set_pagelayout('standard');
+$PAGE->set_pagelayout('incourse');
 $PAGE->set_title($title . " : " . $course->fullname);
 $PAGE->set_heading($title . " : " . $course->fullname);
 $PAGE->requires->css('/blocks/personality_test/styles.css');
@@ -79,7 +83,8 @@ $data = [
     'csv_url' => (new moodle_url('/blocks/personality_test/download_csv.php', ['courseid' => $courseid, 'sesskey' => sesskey()]))->out(false),
     'pdf_url' => (new moodle_url('/blocks/personality_test/download_pdf.php', ['courseid' => $courseid, 'sesskey' => sesskey()]))->out(false),
     'course_url' => (new moodle_url('/course/view.php', ['id' => $courseid]))->out(false),
-    'search_term' => $search
+    'search_term' => $search,
+    'can_delete' => has_capability('block/personality_test:deletestudentdata', $context),
 ];
 
 // Handle Delete Confirmation
@@ -256,6 +261,7 @@ if ($participants) {
             'is_completed' => ($p->is_completed == 1),
             'created_at' => userdate($p->created_at, get_string('strftimedatetimeshort')),
             'view_url' => (new moodle_url('/blocks/personality_test/view_individual.php', ['cid' => $courseid, 'userid' => $p->user]))->out(false),
+            'can_delete' => has_capability('block/personality_test:deletestudentdata', $context),
             'delete_url' => (new moodle_url('/blocks/personality_test/admin_view.php', ['cid' => $courseid, 'action' => 'delete', 'userid' => $p->user, 'sesskey' => sesskey()]))->out(false)
         ];
         

--- a/block_personality_test.php
+++ b/block_personality_test.php
@@ -99,7 +99,7 @@ class block_personality_test extends block_base
         $filtered_student_ids = array();
         foreach ($student_ids as $candidateid) {
             $candidateid = (int)$candidateid;
-            if (has_capability('block/personality_test:viewreports', $context, $candidateid)) {
+            if (has_capability('block/personality_test:viewstudentdata', $context, $candidateid)) {
                 continue;
             }
             $filtered_student_ids[] = $candidateid;
@@ -183,6 +183,21 @@ class block_personality_test extends block_base
         }
         
         $content->text = $OUTPUT->render_from_template('block_personality_test/teacher_dashboard', $template_data);
+        return $content;
+    }
+
+    private function get_secure_admin_content($COURSE) {
+        global $OUTPUT;
+
+        $content = new stdClass();
+        $content->text = $OUTPUT->render_from_template('block_personality_test/admin_launcher', [
+            'icon_html' => $this->get_personality_test_icon('4em', '', true),
+            'security_label' => get_string('sensitive_data', 'block_personality_test'),
+            'title' => get_string('management_title', 'block_personality_test'),
+            'admin_url' => (new moodle_url('/blocks/personality_test/admin_view.php', ['cid' => $COURSE->id]))->out(false),
+            'button_label' => get_string('open_admin_panel', 'block_personality_test'),
+        ]);
+        $content->footer = '';
         return $content;
     }
 
@@ -284,20 +299,10 @@ class block_personality_test extends block_base
 
         $context = context_course::instance($COURSE->id);
 
-        // Si el usuario tiene permiso de ver reportes, mostrar la vista del profesor/administración.
-        if (has_capability('block/personality_test:viewreports', $context)) {
-            $teacher_content = $this->_get_teacher_content($DB, $COURSE);
+        // Los resultados se consultan desde el panel protegido, sin métricas en el curso.
+        if (has_capability('block/personality_test:viewstudentdata', $context)) {
+            $teacher_content = $this->get_secure_admin_content($COURSE);
             $this->content = $teacher_content;
-            
-            // Agregar enlace a la vista administrativa
-            $admin_url = new moodle_url('/blocks/personality_test/admin_view.php', array('cid' => $COURSE->id));
-            $this->content->footer .= html_writer::div(
-                html_writer::link($admin_url,
-                    get_string('go_to_administration', 'block_personality_test'),
-                    array('class' => 'btn btn-sm mt-2', 'style' => 'background: linear-gradient(135deg, #00bf91 0%, #00a07a 100%); color: white; padding: 5px 10px; border-radius: 4px; text-decoration: none; border: none;')
-                ),
-                'text-center'
-            );
             return $this->content;
         }
 

--- a/db/access.php
+++ b/db/access.php
@@ -24,21 +24,24 @@ $capabilities = array(
         'clonepermissionsfrom' => 'moodle/site:manageblocks'
     ),
 
-    'block/personality_test:viewreports' => array(
-        'captype' => 'read',
-        'contextlevel' => CONTEXT_COURSE,
-        'archetypes' => array(
-            'teacher' => CAP_ALLOW,
-            'editingteacher' => CAP_ALLOW,
-            'manager' => CAP_ALLOW
-        )
-    ),
-
     'block/personality_test:taketest' => array(
         'captype' => 'read',
         'contextlevel' => CONTEXT_COURSE,
         'archetypes' => array(
             'student' => CAP_ALLOW
         )
+    ),
+
+    // Los resultados de personalidad requieren una concesión explícita.
+    'block/personality_test:viewstudentdata' => array(
+        'riskbitmask' => RISK_PERSONAL,
+        'captype' => 'read',
+        'contextlevel' => CONTEXT_COURSE
+    ),
+
+    'block/personality_test:deletestudentdata' => array(
+        'riskbitmask' => RISK_DATALOSS | RISK_PERSONAL,
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_COURSE
     ),
 );

--- a/download_pdf.php
+++ b/download_pdf.php
@@ -44,7 +44,7 @@ if ($userid) {
     $context = context_course::instance($course->id);
     require_login($course, false);
 
-    $canviewreports = has_capability('block/personality_test:viewreports', $context);
+    $canviewreports = has_capability('block/personality_test:viewstudentdata', $context);
     if (!$canviewreports && (int)$userid !== (int)$USER->id) {
         redirect(new moodle_url('/course/view.php', ['id' => $course->id]));
     }

--- a/lang/en/block_personality_test.php
+++ b/lang/en/block_personality_test.php
@@ -1,4 +1,9 @@
 <?php
+$string['personality_test:viewstudentdata'] = 'View sensitive student data';
+$string['personality_test:deletestudentdata'] = 'Delete sensitive student data';
+$string['personality_test:taketest'] = 'Take the personality exploration';
+$string['sensitive_data'] = 'Sensitive data';
+$string['open_admin_panel'] = 'Open administration panel';
 $string['pluginname'] = 'Personality Exploration';
 $string['course_overview'] = 'Course Overview';
 $string['management_title'] = 'Personality Exploration Management';

--- a/lang/es/block_personality_test.php
+++ b/lang/es/block_personality_test.php
@@ -1,4 +1,9 @@
 <?php
+$string['personality_test:viewstudentdata'] = 'Ver datos sensibles de estudiantes';
+$string['personality_test:deletestudentdata'] = 'Eliminar datos sensibles de estudiantes';
+$string['personality_test:taketest'] = 'Realizar la exploración de personalidad';
+$string['sensitive_data'] = 'Datos sensibles';
+$string['open_admin_panel'] = 'Abrir panel de administración';
 $string['pluginname'] = 'Exploración de Personalidad';
 $string['management_title'] = 'Gestión - Exploración de Personalidad';
 $string['course_overview'] = 'Resumen del Curso';

--- a/lib.php
+++ b/lib.php
@@ -77,7 +77,7 @@ function block_personality_test_get_report_data($courseid) {
     require_login($course, false);
     
     // Check permissions
-    if (!has_capability('block/personality_test:viewreports', $context)) {
+    if (!has_capability('block/personality_test:viewstudentdata', $context)) {
         return false;
     }
     
@@ -89,7 +89,7 @@ function block_personality_test_get_report_data($courseid) {
     $student_ids = array();
     foreach ($enrolled_ids as $candidateid) {
         $candidateid = (int)$candidateid;
-        if (has_capability('block/personality_test:viewreports', $context, $candidateid)) {
+        if (has_capability('block/personality_test:viewstudentdata', $context, $candidateid)) {
             continue;
         }
         $student_ids[] = $candidateid;

--- a/templates/admin_launcher.mustache
+++ b/templates/admin_launcher.mustache
@@ -1,0 +1,6 @@
+<div class="savio-admin-launcher text-center" style="padding: 1.25rem 1rem; border: 1px solid #caeee3; border-radius: 14px; background: linear-gradient(145deg, #fbfffd 0%, #e9faf5 100%); box-shadow: 0 8px 20px rgba(0, 191, 145, .10);">
+    <div style="margin: 0 auto .85rem; line-height: 0;">{{{icon_html}}}</div>
+    <div class="small font-weight-bold text-uppercase" style="letter-spacing: .07em; color: #008a69;"><i class="fa fa-lock mr-1"></i>{{security_label}}</div>
+    <h6 class="mt-2 mb-2 font-weight-bold">{{title}}</h6>
+    <a href="{{admin_url}}" class="btn btn-sm btn-block" style="background: linear-gradient(135deg, #00bf91 0%, #00a07a 100%); color: #fff !important; border: 0; font-weight: 700; border-radius: 8px;"><i class="fa fa-arrow-right mr-1"></i>{{button_label}}</a>
+</div>

--- a/templates/admin_view.mustache
+++ b/templates/admin_view.mustache
@@ -203,9 +203,11 @@
                                     <a href="{{view_url}}" class="btn btn-sm btn-info mr-2" title="{{#str}}view_results, block_personality_test{{/str}}">
                                         <i class="fa fa-eye"></i> {{#str}}view, block_personality_test{{/str}}
                                     </a>
-                                    <a href="{{delete_url}}" class="btn btn-sm btn-danger" title="{{#str}}delete_participation, block_personality_test{{/str}}">
-                                        <i class="fa fa-trash"></i> {{#str}}delete, block_personality_test{{/str}}
-                                    </a>
+                                    {{#can_delete}}
+                                        <a href="{{delete_url}}" class="btn btn-sm btn-danger" title="{{#str}}delete_participation, block_personality_test{{/str}}">
+                                            <i class="fa fa-trash"></i> {{#str}}delete, block_personality_test{{/str}}
+                                        </a>
+                                    {{/can_delete}}
                                 </td>
                             </tr>
                             {{/list}}

--- a/templates/individual_view.mustache
+++ b/templates/individual_view.mustache
@@ -104,10 +104,10 @@
                         <a href='{{download_url}}' class='btn mr-3' style='background: linear-gradient(135deg, #28a745 0%, #1e7e34 100%) !important; border: none; color: white;'>
                             <i class='fa fa-download'></i> {{download_pdf_label}}
                         </a>
-                        {{#can_view_reports}}
+                        {{#can_delete}}
                         <a href='{{delete_url}}' class='btn btn-danger' onclick='return confirm("{{confirm_delete_msg}}")'>
                             <i class='fa fa-trash'></i> {{delete_results_label}}
-                        {{/can_view_reports}}
+                        {{/can_delete}}
                         </a>
                     </div>
 

--- a/version.php
+++ b/version.php
@@ -10,8 +10,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2026011801; // YYYYMMDDXX (year, month, day, 2-digit version number).
+$plugin->version = 2026072800; // YYYYMMDDXX (year, month, day, 2-digit version number).
 $plugin->requires = 2022041900; // Moodle 4.0+
 $plugin->component = 'block_personality_test';
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '2.0.4';
+$plugin->release = '2.0.5';

--- a/view.php
+++ b/view.php
@@ -35,7 +35,7 @@ if (!$DB->record_exists('block_instances', array('blockname' => 'personality_tes
 }
 
 // If a user with reporting capability tries to open the student test view, redirect them to admin silently
-if (has_capability('block/personality_test:viewreports', $context) && !has_capability('block/personality_test:taketest', $context)) {
+if (has_capability('block/personality_test:viewstudentdata', $context) && !has_capability('block/personality_test:taketest', $context)) {
     redirect(new moodle_url('/blocks/personality_test/admin_view.php', array('cid' => $courseid)), get_string('teachers_redirect_message', 'block_personality_test'), null, \core\output\notification::NOTIFY_INFO);
 }
 

--- a/view_individual.php
+++ b/view_individual.php
@@ -21,7 +21,7 @@ $test_result = $DB->get_record('personality_test', array('user' => $userid));
 
 // Verificar permisos y manejo de privacidad
 $is_own_results = ($USER->id == $userid);
-$can_view_reports = has_capability('block/personality_test:viewreports', $context);
+$can_view_reports = has_capability('block/personality_test:viewstudentdata', $context);
 
 // Acceso básico: Si no es propietario, ni profesor (con permisos), ni admin -> Redirigir
 if (!$is_own_results && !$can_view_reports) {
@@ -221,7 +221,7 @@ if ($test_result->is_completed == 0) {
         'download_url' => (new moodle_url('/blocks/personality_test/download_pdf.php', array('userid' => $userid, 'cid' => $courseid)))->out(false),
         'download_pdf_label' => get_string('download_pdf', 'block_personality_test'),
         // Permissions for delete action
-        'can_delete' => $can_view_reports,
+        'can_delete' => has_capability('block/personality_test:deletestudentdata', $context),
         'delete_url' => (new moodle_url('/blocks/personality_test/admin_view.php', array('cid' => $courseid, 'action' => 'delete', 'userid' => $userid, 'sesskey' => sesskey())))->out(false),
         'confirm_delete_msg' => get_string('confirm_delete_individual', 'block_personality_test'),
         'delete_results_label' => get_string('delete_results', 'block_personality_test'),


### PR DESCRIPTION
## Resumen
- Reemplaza las métricas visibles del curso por un acceso compacto al panel administrativo.
- Protege consulta, resultados y exportación con `block/personality_test:viewstudentdata`.
- Separa el borrado con `block/personality_test:deletestudentdata` y elimina la capacidad inactiva `viewreports`.
- Actualiza los textos bilingües y el CHANGELOG.

## Validación
- Sintaxis PHP validada.
- Actualización y comprobaciones de Moodle completadas correctamente.